### PR TITLE
use correct java version when creating classpath and remove the emacs

### DIFF
--- a/ensime-test.el
+++ b/ensime-test.el
@@ -85,8 +85,7 @@
        (delete-file ,name))))
 
 (defvar ensime--test-scala-version
-  (or (getenv "ENSIME_TEST_SERVER_VERSION")
-      ensime-default-scala-version))
+  (getenv "ENSIME_TEST_SERVER_VERSION"))
 
 (defvar ensime--test-scala-major-version
   (mapconcat 'int-to-string

--- a/ensime-vars.el
+++ b/ensime-vars.el
@@ -72,28 +72,9 @@
   (unless (equal "/" dir)
     (file-name-directory (directory-file-name dir))))
 
-(defcustom ensime-default-java-home
-  (cond ((getenv "JDK_HOME"))
-        ((getenv "JAVA_HOME"))
-        ((file-exists-p "/usr/libexec/java_home")
-         (s-chomp (shell-command-to-string "/usr/libexec/java_home")))
-        ('t (let ((java (file-truename (executable-find "javac"))))
-              (warn "JDK_HOME and JAVA_HOME are not set, inferring from %s" java)
-              (ensime--parent-dir (ensime--parent-dir java)))))
-  "Location of the JDK's base directory"
-  :type 'string
-  :group 'ensime-server)
-
 (defcustom ensime-default-java-flags ()
   "Flags sent to the java instance when the server is started"
   :type '(repeat string)
-  :group 'ensime-server)
-
-(defcustom ensime-default-scala-version
-  "2.10.4"
-  "Default version of scala. An appropriate version of the server
-   will be obtained. May need to be exact to minor release."
-  :type 'string
   :group 'ensime-server)
 
 (defgroup ensime-mode nil


### PR DESCRIPTION
fallbacks for scala and java versions (they have been required .ensime
values for a long time)
